### PR TITLE
add display name tag

### DIFF
--- a/data/auto-excavator/functions/destroy/destroy.mcfunction
+++ b/data/auto-excavator/functions/destroy/destroy.mcfunction
@@ -10,4 +10,11 @@ execute as @s[scores={range=32}] run summon item ~ ~ ~ {Item:{id:"armor_stand",C
 
 execute as @e[tag=auto-excavator,tag=worker,tag=mining] if score @s id = @e[tag=auto-excavator,tag=core,tag=mining,distance=0,limit=1] pair at @s run tp ~ -5 ~
 execute as @e[tag=auto-excavator,tag=worker,tag=mining] if score @s id = @e[tag=auto-excavator,tag=core,tag=mining,distance=0,limit=1] pair run kill @s
+
+#remove display exavator grade
+execute as @e[tag=display-ae-grade,sort=nearest,limit=1] run kill @s
+
+#remove display range
+execute as @e[tag=display-range,sort=nearest,limit=1] run kill @s
+
 kill @s

--- a/data/auto-excavator/functions/destroy/destroy.mcfunction
+++ b/data/auto-excavator/functions/destroy/destroy.mcfunction
@@ -11,10 +11,10 @@ execute as @s[scores={range=32}] run summon item ~ ~ ~ {Item:{id:"armor_stand",C
 execute as @e[tag=auto-excavator,tag=worker,tag=mining] if score @s id = @e[tag=auto-excavator,tag=core,tag=mining,distance=0,limit=1] pair at @s run tp ~ -5 ~
 execute as @e[tag=auto-excavator,tag=worker,tag=mining] if score @s id = @e[tag=auto-excavator,tag=core,tag=mining,distance=0,limit=1] pair run kill @s
 
-#remove display exavator grade
-execute as @e[tag=display-ae-grade,sort=nearest,limit=1] run kill @s
+# remove display excavator grade
+execute as @e[tag=auto-excavator,tag=display-grade,sort=nearest,limit=1] run kill @s
 
-#remove display range
-execute as @e[tag=display-range,sort=nearest,limit=1] run kill @s
+# remove display range
+execute as @e[tag=auto-excavator,tag=display-range,sort=nearest,limit=1] run kill @s
 
 kill @s

--- a/data/auto-excavator/functions/service/generate.mcfunction
+++ b/data/auto-excavator/functions/service/generate.mcfunction
@@ -19,16 +19,16 @@ execute if entity @s[tag=range8] run scoreboard players set @e[tag=auto-excavato
 execute if entity @s[tag=range16] run scoreboard players set @e[tag=auto-excavator,tag=core,tag=init, sort=nearest,limit=1] range 16
 execute if entity @s[tag=range32] run scoreboard players set @e[tag=auto-excavator,tag=core,tag=init, sort=nearest,limit=1] range 32
 
-#display excavator grade
-execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§a基本自動採掘機"}'}
-execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§c発展自動採掘機"}'}
-execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§b精鋭自動採掘機"}'}
-execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§d究極自動採掘機"}'}
+# display excavator grade
+execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.1 ~ {Tags:["auto-excavator","display-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§a基本自動採掘機"}'}
+execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.1 ~ {Tags:["auto-excavator","display-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§c発展自動採掘機"}'}
+execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.1 ~ {Tags:["auto-excavator","display-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§b精鋭自動採掘機"}'}
+execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.1 ~ {Tags:["auto-excavator","display-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§d究極自動採掘機"}'}
 
-#display-range
-execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 1 (3x3)"}'}
-execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 8 (17x17)"}'}
-execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 16 (33x33)"}'}
-execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 32 (65x65)"}'}
+# display-range
+execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.4 ~ {Tags:["auto-excavator","display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 1 (3x3)"}'}
+execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.4 ~ {Tags:["auto-excavator","display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 8 (17x17)"}'}
+execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.4 ~ {Tags:["auto-excavator","display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 16 (33x33)"}'}
+execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.4 ~ {Tags:["auto-excavator","display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 32 (65x65)"}'}
 
 kill @s

--- a/data/auto-excavator/functions/service/generate.mcfunction
+++ b/data/auto-excavator/functions/service/generate.mcfunction
@@ -18,4 +18,17 @@ execute if entity @s[tag=range1] run scoreboard players set @e[tag=auto-excavato
 execute if entity @s[tag=range8] run scoreboard players set @e[tag=auto-excavator,tag=core,tag=init, sort=nearest,limit=1] range 8
 execute if entity @s[tag=range16] run scoreboard players set @e[tag=auto-excavator,tag=core,tag=init, sort=nearest,limit=1] range 16
 execute if entity @s[tag=range32] run scoreboard players set @e[tag=auto-excavator,tag=core,tag=init, sort=nearest,limit=1] range 32
+
+#display excavator grade
+execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§a基本自動採掘機"}'}
+execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§c発展自動採掘機"}'}
+execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§b精鋭自動採掘機"}'}
+execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.1 ~ {Tags:["display-ae-grade"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"§d究極自動採掘機"}'}
+
+#display-range
+execute if entity @s[tag=range1] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 1 (3x3)"}'}
+execute if entity @s[tag=range8] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 8 (17x17)"}'}
+execute if entity @s[tag=range16] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 16 (33x33)"}'}
+execute if entity @s[tag=range32] run summon armor_stand ~ ~-0.4 ~ {Tags:["display-range"],CustomNameVisible:1b,NoGravity:1b,Invisible:1b,CustomName:'{"text":"Range = 32 (65x65)"}'}
+
 kill @s


### PR DESCRIPTION
# 概要
<!-- 変更の目的 -->
配置された採掘機のグレードを外見から判別できるようにする
# 変更内容
<!-- 機能の説明 -->
採掘機を設置した時にどのグレードでどれくらいの範囲を採掘できるのか上に表示するネームプレート(`armor_stand`)を配置する
表示する内容はより良いものがあれば変更してもおｋ
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
分からない
# テスト
## テストの有無
テストは既にした　本体破壊時に一緒にネームプレート(`armor_stand`)が削除される
![2021-06-09_00 23 41](https://user-images.githubusercontent.com/82772868/121214091-c5532e80-c8b9-11eb-91ed-aaf499d45d16.png)


## すでに実施済みのテスト内容
<!-- 説明をここに書く -->

## テストに必要な環境変数 / 依存関係 など
<!-- 説明をここに書く -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
現状`hopper_side.json`の`model`を条件によって置き換える方法が分からないため
グレード事にモデルを変えて判別できるように出来ない

モデルとテクスチャは一応作成済み（できる人いたらやり方教えて）